### PR TITLE
Feat/add book to shelf

### DIFF
--- a/components/Book.tsx
+++ b/components/Book.tsx
@@ -4,7 +4,7 @@ export default function Book({
   title = "No title found",
   cover = "http://lgimages.s3.amazonaws.com/nc-md.gif",
   author = "author not found",
-  description = "description not found",
+  description = "",
   rating = 0,
   review = "",
 }) {
@@ -32,7 +32,11 @@ export default function Book({
           ) : null}
         </div>
       </div>
-      <p className="mt-4 h-24 line-clamp-4 text-justify">
+      <p
+        className={
+          review || description ? `mt-4 h-24 line-clamp-4 text-justify` : ""
+        }
+      >
         {review ? review : description}
       </p>
     </article>

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -71,7 +71,7 @@ export default function Search() {
           />
         </div>
         <Button className="mt-6" variant="outlined" ripple={true} type="submit">
-          Submit
+          Find Book
         </Button>
       </form>
     </section>

--- a/components/Shelf.tsx
+++ b/components/Shelf.tsx
@@ -1,18 +1,18 @@
 import { useRouter } from "next/router";
 import Book from "./Book";
 import { BookContext } from "@/context/book";
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 
 export default function Shelf({ books }) {
   const [book, setBook] = useContext(BookContext);
   const router = useRouter();
-  useEffect(() => console.log(book), [book]);
+
   const formattedBooks = books.map((item) => (
     <button
       key={item.id}
       onClick={() => {
         setBook(item);
-        router.push(`/add-book-to-shelf/${item.title}&${item.author}`);
+        router.push(`/add-book?${item.title}&${item.author}`);
       }}
     >
       <Book

--- a/components/Shelf.tsx
+++ b/components/Shelf.tsx
@@ -1,16 +1,29 @@
+import { useRouter } from "next/router";
 import Book from "./Book";
+import { BookContext } from "@/context/book";
+import { useContext, useEffect } from "react";
 
 export default function Shelf({ books }) {
+  const [book, setBook] = useContext(BookContext);
+  const router = useRouter();
+  useEffect(() => console.log(book), [book]);
   const formattedBooks = books.map((item) => (
-    <Book
+    <button
       key={item.id}
-      title={item.title}
-      cover={item.cover}
-      author={item.author}
-      description={item.description}
-      rating={item.rating}
-      review={item.review}
-    />
+      onClick={() => {
+        setBook(item);
+        router.push(`/add-book-to-shelf/${item.title}&${item.author}`);
+      }}
+    >
+      <Book
+        title={item.title}
+        cover={item.cover}
+        author={item.author}
+        description={item.description}
+        rating={item.rating}
+        review={item.review}
+      />
+    </button>
   ));
   return <section>{formattedBooks.length ? formattedBooks : null}</section>;
 }

--- a/context/book.tsx
+++ b/context/book.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext, useState } from "react";
+
+export const BookContext = createContext(null);
+
+export function BookInfoProvider({ children }) {
+  const [book, setBook] = useState(null);
+  return (
+    <BookContext.Provider value={[book, setBook]}>
+      {children}
+    </BookContext.Provider>
+  );
+}
+
+export function useBookContext() {
+  return useContext(BookContext);
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,11 @@
 // These styles apply to every route in the application
 import "@/styles/globals.css";
+import { BookInfoProvider } from "@/context/book";
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  return (
+    <BookInfoProvider>
+      <Component {...pageProps} />
+    </BookInfoProvider>
+  );
 }

--- a/pages/add-book.tsx
+++ b/pages/add-book.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Radio, Button, Textarea } from "@material-tailwind/react";
+import { Radio, Button, Textarea, Slider } from "@material-tailwind/react";
 import { BookContext } from "@/context/book";
 import { useContext } from "react";
 import Book from "@/components/Book";
@@ -7,6 +7,12 @@ import Book from "@/components/Book";
 export default function AddBook() {
   const [shelf, setShelf] = useState(null);
   const [book] = useContext(BookContext);
+  const [sliderValue, setSliderValue] = useState(50);
+  const [review, setReview] = useState("");
+
+  const handleSubmit = () => {
+    console.log;
+  };
 
   return (
     <section className="m-6">
@@ -17,7 +23,7 @@ export default function AddBook() {
         cover={book.cover}
         description={book.description}
       />
-      <form>
+      <form onSubmit={handleSubmit}>
         <h2>Which shelf would you like to add this to?</h2>
         <div className="flex flex-col gap-3 mt-4">
           <Radio
@@ -33,9 +39,33 @@ export default function AddBook() {
             onChange={() => setShelf("want")}
           />
         </div>
-        <div className="mt-6">
-          <Textarea label="What did you think about this book?" />
-        </div>
+        {shelf === "already" ? (
+          <div className="mt-6">
+            <div className="flex justify-between items-center">
+              <div className="w-4/5">
+                <h2 className="mb-4">What would you rate this book?</h2>
+                <Slider
+                  size="sm"
+                  defaultValue={50}
+                  value={sliderValue}
+                  onChange={(e) => {
+                    setSliderValue(parseInt(e.target.value));
+                  }}
+                  className="mb-8"
+                />
+              </div>
+              <p>{Math.round(sliderValue / 10)}</p>
+            </div>
+            <Textarea
+              value={review}
+              onChange={(e) => {
+                setReview(e.target.value);
+                console.log(review);
+              }}
+              label="What did you think about this book?"
+            />
+          </div>
+        ) : null}
         <Button
           className="mt-6"
           variant="outlined"

--- a/pages/add-book.tsx
+++ b/pages/add-book.tsx
@@ -58,10 +58,7 @@ export default function AddBook() {
             </div>
             <Textarea
               value={review}
-              onChange={(e) => {
-                setReview(e.target.value);
-                console.log(review);
-              }}
+              onChange={(e) => setReview(e.target.value)}
               label="What did you think about this book?"
             />
           </div>

--- a/pages/add-book.tsx
+++ b/pages/add-book.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import { Radio, Button, Textarea } from "@material-tailwind/react";
+import { BookContext } from "@/context/book";
+import { useContext } from "react";
+import Book from "@/components/Book";
+
+export default function AddBook() {
+  const [shelf, setShelf] = useState(null);
+  const [book] = useContext(BookContext);
+
+  return (
+    <section className="m-6">
+      <h1 className="text-xl">Add book to your shelf</h1>
+      <Book
+        title={book.title}
+        author={book.author}
+        cover={book.cover}
+        description={book.description}
+      />
+      <form>
+        <h2>Which shelf would you like to add this to?</h2>
+        <div className="flex flex-col gap-3 mt-4">
+          <Radio
+            ripple={false}
+            name="type"
+            label="Already Read Shelf"
+            onChange={() => setShelf("already")}
+          />
+          <Radio
+            ripple={false}
+            name="type"
+            label="Want to Read Shelf"
+            onChange={() => setShelf("want")}
+          />
+        </div>
+        <div className="mt-6">
+          <Textarea label="What did you think about this book?" />
+        </div>
+        <Button
+          className="mt-6"
+          variant="outlined"
+          ripple={true}
+          type="submit"
+          disabled={!shelf}
+        >
+          Add book
+        </Button>
+      </form>
+    </section>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,5 @@
 import Search from "@/components/Search";
-import Shelf from "@/components/Shelf";
 import Image from "next/image";
-
 export default function Home() {
   return (
     <>


### PR DESCRIPTION
### Changes:
* This utilizes the `useContext` hook to allow a book to be saved to it and accessed globally
* Each book in the search results is a button that takes you to the 'add-book' page
* The add book page allows users to select if they have read the selected book yet or not
* If the book has already been read, it prompts the user to select a rating and review for the book

### Comments/Questions:
* Still need to adapt a color scheme and make the site look good on the web vs mobile
* Next is adding sample data for an already-read bookshelf and creating the pages for the want to read and the already read shelves
* Do i need to have the ISBN available and stored with the data for future iterations of possible scraping a website for book descriptions since many don't have it with this API?