### PR TITLE
Fix/shelf_vs_result

### DIFF
--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -1,0 +1,40 @@
+import { useRouter } from "next/router";
+import Book from "./Book";
+import { BookContext } from "@/context/book";
+import { useContext } from "react";
+import { SearchResult } from "@/types/types";
+type SearchResultsProps = { results: SearchResult[] };
+
+export default function SearchResults({ results }: SearchResultsProps) {
+  const { setBook } = useContext(BookContext);
+  const router = useRouter();
+
+  const formattedBooks = results.map((item) => (
+    <button
+      key={item.id}
+      onClick={() => {
+        setBook(item);
+        console.log(item);
+        router.push(`/add-book?${item.title}&${item.author}`);
+      }}
+    >
+      <Book
+        title={item.title}
+        cover={item.cover}
+        author={item.author}
+        description={item.description}
+      />
+    </button>
+  ));
+  return (
+    <section>
+      <h1 className="m-6">Results</h1>
+      {formattedBooks.length ? (
+        formattedBooks
+      ) : (
+        <p>You don&apos;t have any books on this shelf yet.</p>
+        //this is showing up after searching for a book and the fetch is taking place (loading) momentarily before
+      )}
+    </section>
+  );
+}

--- a/components/Shelf.tsx
+++ b/components/Shelf.tsx
@@ -1,41 +1,23 @@
-import { useRouter } from "next/router";
 import Book from "./Book";
-import { BookContext } from "@/context/book";
-import { useContext } from "react";
 import { BookType } from "@/types/types";
 
-type ShelfProps = { books: BookType[]; type: string; heading: string };
+type ShelfProps = { books: BookType[]; shelfType: string };
 
-export default function Shelf({ books, type, heading }: ShelfProps) {
-  const { setBook } = useContext(BookContext);
-  const router = useRouter();
-
+export default function Shelf({ books, shelfType }: ShelfProps) {
   const formattedBooks = books.map((item) => (
-    <button
+    <Book
       key={item.id}
-      onClick={() => {
-        setBook(item);
-        console.log(item);
-        if (type === "search") {
-          router.push(`/add-book?${item.title}&${item.author}`);
-        } else {
-          router.push(`/book-details?${item.title}&${item.author}`);
-        }
-      }}
-    >
-      <Book
-        title={item.title}
-        cover={item.cover}
-        author={item.author}
-        description={item.description}
-        rating={item.rating}
-        review={item.review}
-      />
-    </button>
+      title={item.title}
+      cover={item.cover}
+      author={item.author}
+      description={item.description}
+      rating={item.rating}
+      review={item.review}
+    />
   ));
   return (
     <section>
-      <h1 className="m-6">{heading}</h1>
+      <h1 className="m-6">{shelfType}</h1>
       {formattedBooks.length ? (
         formattedBooks
       ) : (

--- a/context/book.tsx
+++ b/context/book.tsx
@@ -1,7 +1,7 @@
-import { BookType } from "@/types/types";
+import { BookType, SearchResult } from "@/types/types";
 import { createContext } from "react";
 
 export const BookContext = createContext({
   book: null as BookType | null,
-  setBook: (book: BookType) => {},
+  setBook: (book: BookType | SearchResult) => {},
 });

--- a/pages/bookshelf/already-read.tsx
+++ b/pages/bookshelf/already-read.tsx
@@ -8,11 +8,7 @@ export default function AlreadyRead() {
     getBooks("already_read").then((data) => setBooks(data));
   }, []);
   return books ? (
-    <Shelf
-      books={books}
-      type={"already"}
-      heading={"Books You've Already Read"}
-    />
+    <Shelf books={books} shelfType={"Books You've Already Read"} />
   ) : null;
 }
 

--- a/pages/bookshelf/want-to-read.tsx
+++ b/pages/bookshelf/want-to-read.tsx
@@ -8,6 +8,6 @@ export default function WantToRead() {
     getBooks("want_to_read").then((data) => setBooks(data));
   }, []);
   return books ? (
-    <Shelf books={books} heading={"Books You Want to Read"} type={"want"} />
+    <Shelf books={books} shelfType={"Books You Want to Read"} />
   ) : null;
 }

--- a/pages/results.tsx
+++ b/pages/results.tsx
@@ -1,3 +1,4 @@
+import SearchResults from "@/components/SearchResults";
 import Shelf from "@/components/Shelf";
 import { SearchResult } from "@/types/types";
 import { useRouter } from "next/router";
@@ -14,13 +15,7 @@ export default function Results() {
     ).then((data) => setBookData(data));
   }, [query]);
 
-  return bookData.length ? (
-    <Shelf
-      books={bookData as any}
-      type={"search"}
-      heading={`Results for '${Object.values(query)}'`}
-    />
-  ) : null;
+  return bookData.length ? <SearchResults results={bookData} /> : null;
 }
 
 async function searchAPI(isbn: string, author: string, title: string) {


### PR DESCRIPTION
### Changes:
* This creates a new component `SearchResults` that renders books with links around them for adding a book
* This utilizes `SearchResults` instead of `Shelf` on the `results` page
* This only uses the `Shelf` component when rendering already read or want to read shelves