### PR TITLE
Fix bug causing errors with non whole numbers

### DIFF
--- a/pages/add-book.tsx
+++ b/pages/add-book.tsx
@@ -6,7 +6,7 @@ import Book from "@/components/Book";
 import { BookType } from "@/types/types";
 import { useRouter } from "next/router";
 
-function getPageUrl(shelf) {
+function getPageUrl(shelf: string) {
   switch (shelf) {
     case "already_read":
       return "/bookshelf/already-read";
@@ -115,7 +115,7 @@ async function addBookToShelf(
       shelfType: shelf,
       cover: book.cover,
       description: book.description,
-      rating: rating,
+      rating: Math.round(rating / 10),
       review: review,
     }),
   });


### PR DESCRIPTION
### Changes:
* This was a last minute bug find and fix.
* This fixes a bug that was crashing the backend when a non-whole number (ex: 8.8) was sent back as a rating.
* It rounds the number to the nearest whole number before sending it to the backend to add a book to the shelf